### PR TITLE
Less verbose error log for nginx

### DIFF
--- a/addon/rootfs/etc/nginx/nginx.conf
+++ b/addon/rootfs/etc/nginx/nginx.conf
@@ -1,6 +1,6 @@
 worker_processes  1;
 pid /var/run/nginx.pid;
-error_log /dev/stdout info;
+error_log /dev/stdout error;
 user nginx nginx;
 
 # Load allowed environment vars
@@ -11,6 +11,7 @@ events {
 }
 
 http {
+    access_log         off;
     include            mime.types;
     default_type       application/octet-stream;
     sendfile           on;


### PR DESCRIPTION
Reduce log level to error as it's not really needed for this addon. 
This avoids info messages like:
```
client x.x.x.x closed keepalive connection
``` 

In addition the access log could be switched off as it enabled per default and also not needed.